### PR TITLE
196 edit setlist bugs improvement

### DIFF
--- a/server/src/controllers/setlist.controllers.ts
+++ b/server/src/controllers/setlist.controllers.ts
@@ -26,9 +26,9 @@ const createSetlist: RequestHandler = async (req: Request, res: Response): Promi
         const setlistUrl = toCreate.publicLink
           ? defaultUrl + toCreate.publicLink
           : defaultUrl + data._id;
-        await Setlist.findByIdAndUpdate(data._id, { publicLink: setlistUrl });
+        const updated = await Setlist.findByIdAndUpdate(data._id, { publicLink: setlistUrl });
 
-        sendResponse(res, 200, data);
+        sendResponse(res, 200, updated);
       } else {
         sendResponse(res, 404, 'Setlist not created');
       }

--- a/server/src/controllers/setlist.controllers.ts
+++ b/server/src/controllers/setlist.controllers.ts
@@ -1,7 +1,6 @@
 import { Request, RequestHandler, Response } from 'express';
 import { Setlist } from '../models/setlist.model';
 import { SetlistDocument } from '../types/setlist.types';
-import { nanoid } from 'nanoid';
 
 const sendResponse = (
   res: Response,
@@ -13,24 +12,22 @@ const sendResponse = (
 
 const createSetlist: RequestHandler = async (req: Request, res: Response): Promise<void> => {
   const { ...toCreate }: SetlistDocument = req.body;
-  const defaultUrl: string = req.protocol + '://' + req.get('host') + '/setlist/';
+
+  const defaultUrl: string =
+    (process.env.BASE_URL || req.protocol + '://' + req.get('host')) + '/setlist/view/';
 
   if (Object.keys(toCreate).length > 0) {
     try {
-      const urlSafeId = nanoid(10);
-
-      // this is to set the default url of the public link to setlist/:id,
-      // and to setlist/custom-name if the user define a custom link name
-      const setlistUrl = toCreate.publicLink
-        ? defaultUrl + toCreate.publicLink
-        : defaultUrl + urlSafeId;
-
-      const data: SetlistDocument = await Setlist.create({
-        ...toCreate,
-        publicLink: setlistUrl,
-      });
+      const data: SetlistDocument = await Setlist.create(toCreate);
 
       if (data) {
+        // this is to set the default url of the public link to setlist/:id,
+        // and to setlist/custom-name if the user define a custom link name
+        const setlistUrl = toCreate.publicLink
+          ? defaultUrl + toCreate.publicLink
+          : defaultUrl + data._id;
+        await Setlist.findByIdAndUpdate(data._id, { publicLink: setlistUrl });
+
         sendResponse(res, 200, data);
       } else {
         sendResponse(res, 404, 'Setlist not created');

--- a/server/src/models/setlist.model.ts
+++ b/server/src/models/setlist.model.ts
@@ -8,7 +8,7 @@ const setlistSchema = new Schema<SetlistSchema>(
     createdBy: { type: Schema.Types.ObjectId, ref: 'Ownership' },
     songs: [{ type: Types.ObjectId, ref: 'Song' }],
     lastUpdatedBy: { type: Schema.Types.ObjectId, ref: 'Ownership' },
-    publicLink: { type: String, required: true, unique: true },
+    publicLink: { type: String, required: false, unique: true, default: '' },
     groupIds: [{ type: Types.ObjectId, ref: 'Group' }],
     isDeleted: { type: Boolean, default: false },
   },

--- a/server/src/models/setlist.model.ts
+++ b/server/src/models/setlist.model.ts
@@ -8,7 +8,7 @@ const setlistSchema = new Schema<SetlistSchema>(
     createdBy: { type: Schema.Types.ObjectId, ref: 'Ownership' },
     songs: [{ type: Types.ObjectId, ref: 'Song' }],
     lastUpdatedBy: { type: Schema.Types.ObjectId, ref: 'Ownership' },
-    publicLink: { type: String, required: false, unique: true, default: '' },
+    publicLink: { type: String, required: false, unique: true, sparse: true, default: null },
     groupIds: [{ type: Types.ObjectId, ref: 'Group' }],
     isDeleted: { type: Boolean, default: false },
   },

--- a/ui/src/components/setlist/SetlistEditorContainer.tsx
+++ b/ui/src/components/setlist/SetlistEditorContainer.tsx
@@ -632,9 +632,12 @@ const SetlistEditorContainer: FC<SetlistEditorProps> = () => {
       // Success - clear errors and redirect
       setInvalidSetlist('');
       setSuccessSnackbarOpen(true);
-      navigate(
-        isTablet || isDesktop ? `/setlist/${savedSetlistId}` : `/setlist/details/${savedSetlistId}`
-      );
+      //TODO: Find a better way to redirect to list and refetch the newly created/updated setlist.
+      if (isTablet || isDesktop) {
+        window.location.href = `/setlist/${savedSetlistId}`;
+      } else {
+        window.location.href = `/setlist/details/${savedSetlistId}`;
+      }
     } catch (error: any) {
       console.error('Error saving setlist:', error);
       setInvalidSetlist(error.response?.data || 'Error saving setlist');

--- a/ui/src/components/setlist/SetlistEditorContainer.tsx
+++ b/ui/src/components/setlist/SetlistEditorContainer.tsx
@@ -454,9 +454,15 @@ const SetlistEditorContainer: FC<SetlistEditorProps> = () => {
 
   useEffect(() => {
     getSongResults();
-    getSetlist();
+  }, [getSongResults]);
+
+  useEffect(() => {
     getFolderOptions();
-  }, [getSetlist, getFolderOptions, getSongResults]);
+  }, [getFolderOptions]);
+
+  useEffect(() => {
+    getSetlist();
+  }, [getSetlist]);
 
   useEffect(() => {
     if (setlist && Object.keys(setlist).length > 0) {

--- a/ui/src/components/setlist/adminView/SetlistAdminViewContainer.tsx
+++ b/ui/src/components/setlist/adminView/SetlistAdminViewContainer.tsx
@@ -120,7 +120,6 @@ const SetlistAdminViewContainer: FC = (): ReactElement | null => {
       setSnackbar({ open: true, message: 'No public link available' });
       return;
     }
-
     try {
       await navigator.clipboard.writeText(setlist.publicLink);
       setSnackbar({ open: true, message: 'Setlist Public Link copied to clipboard' });
@@ -135,8 +134,8 @@ const SetlistAdminViewContainer: FC = (): ReactElement | null => {
   }, [navigate, id]);
 
   const handlePublicViewClick = useCallback(() => {
-    navigate(`/setlist/view/${id}`);
-  }, [navigate, id]);
+    window.open(`/setlist/view/${id}`, '_blank');
+  }, [id]);
 
   const handleCloseSnackbar = useCallback((_: any, reason?: string) => {
     if (reason === 'clickaway') return;


### PR DESCRIPTION
enhancement:
    "Copy Link" button should Link to the Public View of the setlist
    "View Public Link" button opens a NEW tab of the Public View of the setlist

bug:
steps to reproduce:
    Find existing setlist and click edit
    ⁠Type in a new song in search bar
    ⁠add song
    ⁠Clear search bar
    ⁠Type new song

The first song that was added would disappear from the setlist again after clearing the search bar